### PR TITLE
Skipping golangci-lint if executable isn't installed

### DIFF
--- a/internal/dirs.go
+++ b/internal/dirs.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"os"
+	"os/exec"
 	"path"
 
 	"github.com/wavesoftware/go-ensure"
@@ -17,4 +18,11 @@ func EnsureBuildDir() {
 func DontExists(file string) bool {
 	_, err := os.Stat(file)
 	return err != nil && os.IsNotExist(err)
+}
+
+// ExecutableAvailable will return true if given executable in available in
+// system env.PATH's.
+func ExecutableAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
 }

--- a/pkg/checks/golangci_lint.go
+++ b/pkg/checks/golangci_lint.go
@@ -1,11 +1,16 @@
 package checks
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/magefile/mage/sh"
 	"github.com/wavesoftware/go-magetasks/config"
 	"github.com/wavesoftware/go-magetasks/internal"
+)
+
+const (
+	golangciLintName = "golangci-lint"
 )
 
 // GolangCiLintOptions contains options for GolangCi Lint.
@@ -27,7 +32,7 @@ func GolangCiLint() {
 // options.
 func GolangCiLintWithOptions(opts GolangCiLintOptions) {
 	config.Checks = append(config.Checks, config.CustomTask{
-		Name: "golangci-lint",
+		Name: golangciLintName,
 		Task: func() error {
 			return golangCiLint(opts)
 		},
@@ -35,10 +40,18 @@ func GolangCiLintWithOptions(opts GolangCiLintOptions) {
 }
 
 func golangCiLint(opts GolangCiLintOptions) error {
-	c := path.Join(internal.RepoDir(), ".golangci.yaml")
+	configFile := ".golangci.yaml"
+	c := path.Join(internal.RepoDir(), configFile)
 	if internal.DontExists(c) {
+		fmt.Printf("%s file don't exists. Skipping.\n", configFile)
 		return nil
 	}
+	if !internal.ExecutableAvailable(golangciLintName) {
+		fmt.Printf("%s executable isn't available on system PATH's."+
+			" Skipping.\n", golangciLintName)
+		return nil
+	}
+
 	args := []string{"run"}
 	if opts.Fix {
 		args = append(args, "--fix")
@@ -47,5 +60,5 @@ func golangCiLint(opts GolangCiLintOptions) error {
 		args = append(args, "--new")
 	}
 	args = append(args, "./...")
-	return sh.RunV("golangci-lint", args...)
+	return sh.RunV(golangciLintName, args...)
 }


### PR DESCRIPTION
As title says.