### PR TITLE
:bug: Only reports may be collected to `ARTIFACTS` dir

### DIFF
--- a/pkg/dotenv/loader.go
+++ b/pkg/dotenv/loader.go
@@ -1,10 +1,16 @@
 package dotenv
 
 import (
+	"os"
+
 	"github.com/joho/godotenv"
 )
 
 // Load the .env file.
 func Load() error {
-	return godotenv.Load()
+	err := godotenv.Load()
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }

--- a/pkg/files/dirs.go
+++ b/pkg/files/dirs.go
@@ -3,28 +3,57 @@ package files
 import (
 	"os"
 	"path"
+	"strings"
+	"sync"
 
 	"github.com/magefile/mage/mg"
 	"github.com/wavesoftware/go-ensure"
 	"github.com/wavesoftware/go-magetasks/config"
 	"github.com/wavesoftware/go-magetasks/pkg/dotenv"
 	"github.com/wavesoftware/go-magetasks/pkg/output"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+const randomDirLength = 12
+
+var (
+	randomDir    = "mage-build-" + rand.String(randomDirLength)
+	buildDirOnce sync.Once
 )
 
 // EnsureBuildDir creates a build directory.
 func EnsureBuildDir() {
-	mg.Deps(dotenv.Load, output.Setup)
-	d := path.Join(BuildDir(), "bin")
-	ensure.NoError(os.MkdirAll(d, os.ModePerm))
+	buildDirOnce.Do(func() {
+		mg.Deps(dotenv.Load, output.Setup)
+		d := path.Join(BuildDir(), "bin")
+		ensure.NoError(os.MkdirAll(d, os.ModePerm))
+		ensure.NoError(os.MkdirAll(ReportsDir(), os.ModePerm))
+		if strings.Contains(ReportsDir(), randomDir) {
+			output.Println("📁 Reports directory: ", ReportsDir())
+		}
+	})
 }
 
 // BuildDir returns project build dir.
 func BuildDir() string {
+	buildDir := os.Getenv("MAGE_BUILD_DIR")
+	if buildDir != "" {
+		return buildDir
+	}
+	buildDir = os.Getenv("BUILD_DIR")
+	if buildDir != "" {
+		return buildDir
+	}
+	return relativeTo(ProjectDir(), config.Actual().BuildDirPath...)
+}
+
+// ReportsDir returns project reports directory.
+func ReportsDir() string {
 	artifacts := os.Getenv("ARTIFACTS")
 	if artifacts != "" {
-		return artifacts
+		return path.Join(artifacts, randomDir)
 	}
-	return relativeToProjectRoot(config.Actual().BuildDirPath)
+	return relativeTo(BuildDir(), "reports")
 }
 
 // ProjectDir returns project repo directory.
@@ -37,9 +66,9 @@ func ProjectDir() string {
 	return repoDir
 }
 
-func relativeToProjectRoot(paths []string) string {
+func relativeTo(to string, paths ...string) string {
 	fullpath := make([]string, len(paths)+1)
-	fullpath[0] = ProjectDir()
+	fullpath[0] = to
 	for ix, elem := range paths {
 		fullpath[ix+1] = elem
 	}

--- a/testing.go
+++ b/testing.go
@@ -18,14 +18,14 @@ func Test() {
 	t := tasks.Start("✅", "Testing", true)
 	args := []string{
 		"--format", "testname",
-		"--jsonfile", fmt.Sprintf("%s/tests-output.json", files.BuildDir()),
-		"--junitfile", fmt.Sprintf("%s/tests-results.junit.xml", files.BuildDir()),
+		"--jsonfile", fmt.Sprintf("%s/tests-output.json", files.ReportsDir()),
+		"--junitfile", fmt.Sprintf("%s/tests-results.junit.xml", files.ReportsDir()),
 	}
 	if color.NoColor {
 		args = append(args, "--no-color")
 	}
 	args = append(args, "--",
-		"-covermode=atomic", fmt.Sprintf("-coverprofile=%s/coverage.out", files.BuildDir()),
+		"-covermode=atomic", fmt.Sprintf("-coverprofile=%s/tests-coverage.out", files.ReportsDir()),
 		"-race",
 		"-count=1",
 		"-short",


### PR DESCRIPTION
# Changes

- :bug: Only reports may be collected to `ARTIFACTS` dir
- :bug: No longer fail if `.env` file is missing

## Refs

Fixes #34 
Fixes #33 